### PR TITLE
Update fortios.rb

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -38,6 +38,14 @@ class FortiOS < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    post_login 'config global'
+    post_login 'config system console'
+    post_login 'set output standard'
+    post_login 'end'
+    post_login 'end'
+    pre_logout 'config system console'
+    pre_logout 'set output more'
+    pre_logout 'end'
     pre_logout "exit\n"
   end
 


### PR DESCRIPTION
Fixed this also but had to do a awkard workaround.. as I see it catch 22.

In a vdom environment we have to do 
config global 
then 
config system console 
set output standard 
end 
end

Right now we can't get the 
get system status
to be good since it per default does more.

So I had to just add some commands that will fail on a none vdom enabled router 
but works on a vdom enabled router. Maybe the trick would be to create a class for fortgatevdom ?

I'll try to pull this to the repository... and comments are welcome.
